### PR TITLE
Convert NULL type columns to Julia Missing type

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -370,6 +370,7 @@ juliatype(x::Integer) =
     x == SQLITE_INTEGER ? Int64 :
     x == SQLITE_FLOAT ? Float64 :
     x == SQLITE_TEXT ? String :
+    x == SQLITE_NULL ? Missing :
     Any
 
 # convert SQLite declared type into Julia equivalent,


### PR DESCRIPTION
At the moment columns which are NULL type are returned as Julia type "Any" which is suboptimal for filtering missing values when reading values iteratively.
With this PR a NULL type column is handled as a Missing type in Julia.